### PR TITLE
Add basic WordPress plugin integrating ReactPHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# mcp_wp_flex
-WordPress Plugin for MCP
+# MCP WP Flex
+
+WordPress plugin that demonstrates how to integrate with the [MCP server](https://github.com/php-mcp/server) using [ReactPHP](https://reactphp.org/).
+
+## Installation
+
+1. Install PHP dependencies using Composer:
+
+```bash
+composer install
+```
+
+2. Copy the `mcp-wp-flex` directory into your WordPress `plugins` folder.
+
+3. Activate **MCP WP Flex** from the WordPress admin.
+
+## Running the ReactPHP Server
+
+The plugin can start a simple ReactPHP HTTP server when executed from the command line. For example, using WP‑CLI:
+
+```bash
+MCP_WP_FLEX_SERVER=1 wp eval-file wp-content/plugins/mcp-wp-flex/mcp-wp-flex.php
+```
+
+The server listens on `http://0.0.0.0:8080` and currently returns a JSON response. Integration with the MCP server and Claude AI should be implemented inside `MCP_WP_Flex::start_server()`.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "openai/mcp-wp-flex",
+    "description": "WordPress integration for MCP server using ReactPHP",
+    "type": "project",
+    "license": "GPL-3.0-or-later",
+    "require": {
+        "php": ">=7.4",
+        "react/http": "^1.8",
+        "react/socket": "^1.12"
+    },
+    "autoload": {
+        "psr-4": {
+            "MCPWPFlex\\": "mcp-wp-flex/"
+        }
+    }
+}

--- a/mcp-wp-flex/mcp-wp-flex.php
+++ b/mcp-wp-flex/mcp-wp-flex.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Plugin Name: MCP WP Flex
+ * Description: WordPress integration for MCP server using ReactPHP.
+ * Version: 0.1.0
+ * Author: OpenAI Codex
+ * License: GPLv3 or later
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+// Use composer's autoload if available
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
+}
+
+use React\EventLoop\Loop;
+use React\Http\Browser;
+use React\Http\Server as ReactServer;
+use React\Socket\SocketServer;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Message\Response;
+
+class MCP_WP_Flex {
+    /**
+     * Initialize plugin hooks
+     */
+    public function __construct() {
+        add_action('init', [$this, 'init']);
+    }
+
+    /**
+     * Plugin initialization hook
+     */
+    public function init() {
+        // Placeholder: start ReactPHP server when invoked via CLI (e.g., WP-CLI)
+        if (php_sapi_name() === 'cli' && defined('MCP_WP_FLEX_SERVER') && MCP_WP_FLEX_SERVER) {
+            $this->start_server();
+        }
+    }
+
+    /**
+     * Start a simple ReactPHP HTTP server
+     */
+    public function start_server() {
+        $loop = Loop::get();
+
+        $server = new ReactServer(function (ServerRequestInterface $request) {
+            // TODO: integrate with MCP server logic and Claude AI
+            $data = [
+                'message' => 'MCP WP Flex server running',
+                'path' => $request->getUri()->getPath(),
+            ];
+
+            return new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode($data)
+            );
+        });
+
+        $socket = new SocketServer('0.0.0.0:8080');
+        $server->listen($socket);
+
+        // Output message to CLI
+        echo "MCP WP Flex server listening on http://0.0.0.0:8080\n";
+        $loop->run();
+    }
+
+    /**
+     * Send a request to an MCP server using ReactPHP's Browser
+     *
+     * @param array $payload Data to send
+     * @return \React\Promise\PromiseInterface
+     */
+    public function send_to_mcp(array $payload) {
+        $browser = new Browser();
+        $url = apply_filters('mcp_wp_flex_server_url', 'http://localhost:4000');
+
+        return $browser->post(
+            $url,
+            ['Content-Type' => 'application/json'],
+            json_encode($payload)
+        );
+    }
+}
+
+// Initialize plugin
+new MCP_WP_Flex();


### PR DESCRIPTION
## Summary
- create basic ReactPHP WordPress plugin under `mcp-wp-flex`
- document usage in README
- define composer dependencies

## Testing
- `php -l mcp-wp-flex/mcp-wp-flex.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684c4bf02c4c8331a5a6ec9bd04e9b6d